### PR TITLE
Fixes issue where -n flag is not available

### DIFF
--- a/src/new-kata.sh
+++ b/src/new-kata.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 : "${1?"Please add a project name: [ Usage: $0 PROJECT_NAME ]"}"
 


### PR DESCRIPTION
Looks like if you use `#!/bin/sh` here it will use read from just `sh`, which doesn't always have the `-n` flag available.